### PR TITLE
[AFTA-1455] Remove use of sudo #251

### DIFF
--- a/providers/smb/options.go
+++ b/providers/smb/options.go
@@ -110,10 +110,10 @@ func (s Options) MountCommand(mountPoint string) string {
 
 	opts.WriteString(fmt.Sprintf("\"//%s/%s\" %s", s.Server, s.Share, mountPoint))
 
-	return fmt.Sprintf("sudo mount -t cifs -o %s", opts.String())
+	return fmt.Sprintf("mount -t cifs -o %s", opts.String())
 }
 
 // UnmountCommand .
 func (s Options) UnmountCommand(mountPoint string) string {
-	return fmt.Sprintf("sudo umount -l %s", mountPoint)
+	return fmt.Sprintf("umount -l %s", mountPoint)
 }

--- a/providers/smb/smb.go
+++ b/providers/smb/smb.go
@@ -179,7 +179,7 @@ func (s *smbProvider) TestConnection(options Options) error {
 	output, err := run(options.MountCommand(tmpMountPath))
 	if err != nil {
 		// We had an error, let's see if we can get the error from the output
-		logrus.Debugf("error testing mount for %s: %s: %+v", options.FriendlyName(), output, err)
+		logrus.Warnf("error testing mount for %s: %s: %+v", options.FriendlyName(), output, err)
 		output = extractErrorsFromMountOutput(output)
 		if len(output) == 0 {
 			return fmt.Errorf("could not mount")
@@ -189,7 +189,7 @@ func (s *smbProvider) TestConnection(options Options) error {
 
 	output, err = run(options.UnmountCommand(tmpMountPath))
 	if err != nil {
-		logrus.Debugf("error removing mount after test for %s: %s: %+v", options.FriendlyName(), output, err)
+		logrus.Warnf("error removing mount after test for %s: %s: %+v", options.FriendlyName(), output, err)
 	}
 
 	return nil


### PR DESCRIPTION
* Removes use of `sudo` when mounting / unmounting.  `sudo` in not present on the production system.
* Changes debug log to warning log since debug logs are not displayed by default.
* Testing connectivity of and archiving to both password-protected and anonymous shares are working after this change.